### PR TITLE
Fix: attachment filepath on Linux missing root slash

### DIFF
--- a/src/note.ts
+++ b/src/note.ts
@@ -1,4 +1,4 @@
-import { CachedMetadata, FileSystemAdapter, moment, requestUrl, TFile, View, WorkspaceLeaf } from 'obsidian'
+import { CachedMetadata, FileSystemAdapter, moment, requestUrl, TFile, View, WorkspaceLeaf, Platform } from 'obsidian'
 import { encryptString, sha1 } from './crypto'
 import SharePlugin from './main'
 import StatusMessage, { StatusType } from './StatusMessage'
@@ -339,6 +339,9 @@ export default class Note {
         const srcMatch = src.match(/app:\/\/\w+\/([^?#]+)/)
         if (srcMatch) {
           filepath = window.decodeURIComponent(srcMatch[1])
+          if (!Platform.isLinux) {
+            filepath = filepath.slice(1);
+          }
           content = await FileSystemAdapter.readLocalFile(filepath)
         }
       } else if (src.match(/^https?:\/\/localhost/) || !src.startsWith('http')) {

--- a/src/note.ts
+++ b/src/note.ts
@@ -336,7 +336,7 @@ export default class Note {
       let content
       let filepath = ''
       if (src.startsWith('app://')) {
-        const srcMatch = src.match(/app:\/\/\w+\/([^?#]+)/)
+        const srcMatch = src.match(/app:\/\/\w+(\/[^?#]+)/)
         if (srcMatch) {
           filepath = window.decodeURIComponent(srcMatch[1])
           if (!Platform.isLinux) {


### PR DESCRIPTION
The regular expression for getting an attachment extracts a path without the prepended root slash:
https://github.com/alangrainger/share-note/blob/eebc70b760e1dd5fbe28e146a271f606314541f2/src/note.ts#L339

This causes the following error in the console:
```log
Error: ENOENT: no such file or directory, open 'home/USER/PATH_TO_ATTACHMENT/assets/file.png'
```

This PR changes the regular expression to capture the preceding root slash. Since I'm unsure of the effect on other platforms, I've also added a platform check that removes the slash on non-linux platforms.

https://github.com/alangrainger/share-note/blob/bf10f2e01574f55b01ad8b3d1d66d4011fe92e09/src/note.ts#L342-L344