### PR TITLE
Fix troubleshooting links in GitHub Issue Templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/1--my-shared-note-has-display---visual-issues.md
+++ b/.github/ISSUE_TEMPLATE/1--my-shared-note-has-display---visual-issues.md
@@ -11,7 +11,7 @@ assignees: ''
 
 Firstly, follow the troubleshooting steps here to see if that resolves your problem:
 
-https://docs.note.sx/Troubleshooting
+https://docs.note.sx/troubleshooting
 
 If it still doesn't work, please create a demo vault with the plugins/themes needed to make this issue occur.
 

--- a/.github/ISSUE_TEMPLATE/2--other-issues---bug.md
+++ b/.github/ISSUE_TEMPLATE/2--other-issues---bug.md
@@ -11,4 +11,4 @@ assignees: ''
 
 Before creating an issue, please follow the troubleshooting steps here to see if that resolves your problem:
 
-https://docs.note.sx/Troubleshooting
+https://docs.note.sx/troubleshooting


### PR DESCRIPTION
I was about to report an issue, but wanted to double-check that I couldn't fix it myself, and noticed the links in the issue templates lead to a 404 page (yay capitalization sensitivity!)