### PR TITLE
Allow changing server for using self-hosted one

### DIFF
--- a/src/settings.ts
+++ b/src/settings.ts
@@ -72,6 +72,17 @@ export class ShareSettingsTab extends PluginSettingTab {
 
     containerEl.empty()
 
+    new Setting(containerEl)
+      .setName('Server URL')
+      .setDesc('Use default server URL (https://api.note.sx) or configure your one -> https://github.com/note-sx/server')
+      .addText(text => text
+        .setPlaceholder(DEFAULT_SETTINGS.server)
+        .setValue(this.plugin.settings.server)
+        .onChange(async (value) => {
+          this.plugin.settings.server = value || DEFAULT_SETTINGS.server
+          await this.plugin.saveSettings()
+        }))
+
     // API key
     new Setting(containerEl)
       .setName('API key')

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -72,9 +72,10 @@ export class ShareSettingsTab extends PluginSettingTab {
 
     containerEl.empty()
 
+    // Server
     new Setting(containerEl)
       .setName('Server URL')
-      .setDesc('Use default server URL (https://api.note.sx) or configure your one -> https://github.com/note-sx/server')
+      .setDesc('Use default server URL (https://api.note.sx) or configure your one')
       .addText(text => text
         .setPlaceholder(DEFAULT_SETTINGS.server)
         .setValue(this.plugin.settings.server)
@@ -82,6 +83,7 @@ export class ShareSettingsTab extends PluginSettingTab {
           this.plugin.settings.server = value || DEFAULT_SETTINGS.server
           await this.plugin.saveSettings()
         }))
+      .then(setting => addDocs(setting, 'https://github.com/note-sx/server'))
 
     // API key
     new Setting(containerEl)


### PR DESCRIPTION
Checking the description of the plugin, I saw documentation for self-hosting the server. 

After self-hosting it, I realized you can't actually change it in the plugin configuration so I included. I have tested it with a self-hosted server and works fine: https://obsidian-publish.edulio.tech/vv1ua7jy#teLC3JZbtE3fv5kZsRKXFQIhNmnuiNJsIyJsMXw/+mg

![image](https://github.com/user-attachments/assets/297b708a-9e6c-434b-a299-46e092cdf183)
